### PR TITLE
Zero-copy zero-allocation shared buffer between JVM and NumPy arrays

### DIFF
--- a/src/ai/jni/JNIAI.java
+++ b/src/ai/jni/JNIAI.java
@@ -35,6 +35,7 @@ import rts.GameState;
 import rts.InvalidPlayerActionStats;
 import rts.PlayerAction;
 import rts.units.UnitTypeTable;
+import util.NDBuffer;
 import util.Pair;
 import util.XMLWriter;
 
@@ -73,6 +74,13 @@ public class JNIAI extends AIWithComputationBudget implements JNIInterface {
 
     public PlayerAction getAction(int player, GameState gs, int[][] action) throws Exception {
         Pair<PlayerAction, InvalidPlayerActionStats> p = PlayerAction.fromActionArrays(action, gs, utt, player, maxAttackRadius);
+        p.m_a.fillWithNones(gs, player, 1);
+        ipas = p.m_b;
+        return p.m_a;
+    }
+
+    public PlayerAction getActionFromBuffer(int player, GameState gs, int clientOffset, NDBuffer action) throws Exception {
+        Pair<PlayerAction, InvalidPlayerActionStats> p = PlayerAction.fromActionBuffer(clientOffset, action, gs, utt, player, maxAttackRadius);
         p.m_a.fillWithNones(gs, player, 1);
         ipas = p.m_b;
         return p.m_a;

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -10,6 +10,7 @@ import org.jdom.Element;
 import rts.units.Unit;
 import rts.units.UnitType;
 import rts.units.UnitTypeTable;
+import util.NDBuffer;
 import util.Pair;
 import util.XMLWriter;
 
@@ -30,6 +31,7 @@ public class GameState {
 
     protected int [][][][] matrixObservation;
     public static final int numFeatureMaps = 5;
+    public static final int numFeaturePlanes = 27;
 
     /**
      * Initializes the GameState with a PhysicalGameState and a UnitTypeTable
@@ -814,6 +816,27 @@ public class GameState {
         }
 
         return matrixObservation[player];
+    }
+
+     /*
+    | Observation Features | Planes | Description                                             |
+    |----------------------|--------|---------------------------------------------------------|
+    | Hit Points           | 5      | 0,1,2,3,>=4                                             |
+    | Resources            | 5      | 0,1,2,3,>=4                                             |
+    | Owner                | 3      | player 1,-, player 2                                    |
+    | Unit Types           | 8      | -, resource, base, barrack,worker, light, heavy, ranged |
+    | Current Action       | 6      | -, move, harvest, return, produce, attack               |
+    */
+    public void getBufferObservation(int player, int clientIndex, NDBuffer buffer) {
+        buffer.resetSegment(new int[]{clientIndex});
+
+        for (int i = 0; i < pgs.units.size(); i++) {
+            Unit u = pgs.units.get(i);
+            UnitActionAssignment uaa = unitActions.get(u);
+            buffer.set(new int[]{clientIndex, u.getY(), u.getX(), 0+Math.min(u.getHitPoints(), 5)}, 1);
+            buffer.set(new int[]{clientIndex, u.getY(), u.getX(), 5+Math.min(u.getHitPoints(), 5)}, 1);
+            buffer.set(new int[]{clientIndex, u.getY(), u.getX(), 10+((u.getPlayer()+player)%2)  }, 1);
+        }
     }
 
     /**

--- a/src/rts/PlayerAction.java
+++ b/src/rts/PlayerAction.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.jdom.Element;
 import rts.units.UnitTypeTable;
+import util.NDBuffer;
 import util.Pair;
 import util.XMLWriter;
 
@@ -426,6 +427,52 @@ public class PlayerAction {
             }
         }
         return pa;
+    }
+
+    public static Pair<PlayerAction, InvalidPlayerActionStats> fromActionBuffer(
+            int clientOffset, NDBuffer actions, GameState gs, UnitTypeTable utt, int currentPlayer, int maxAttackRadius) {
+        final PlayerAction pa = new PlayerAction();
+        // calculating the resource usage of existing actions
+        final ResourceUsage base_ru = new ResourceUsage();
+		for (final Unit u : gs.getPhysicalGameState().getUnits()) {
+			final UnitActionAssignment uaa = gs.unitActions.get(u);
+			if (uaa != null) {
+				final ResourceUsage ru = uaa.action.resourceUsage(u, gs.getPhysicalGameState());
+				base_ru.merge(ru);
+			}
+        }
+        pa.setResourceUsage(base_ru);
+
+        final InvalidPlayerActionStats ipas = new InvalidPlayerActionStats();
+        final int[] action = new int[actions.size(2)];
+
+        for(int i=0; i<actions.size(1); i++) {
+            actions.getSegment(new int[]{clientOffset, i}, action);
+            final Unit u = gs.pgs.getUnitAt(action[0] % gs.pgs.width, action[0] / gs.pgs.width);
+            UnitActionAssignment uaa = gs.unitActions.get(u);
+            if (u == null) {
+                ipas.numInvalidActionNull += 1;
+            } else {
+                if (u.getPlayer() != currentPlayer) {
+                    ipas.numInvalidActionOwnership += 1;
+                }
+            }
+
+            if (u != null && u.getPlayer() == currentPlayer && uaa == null) {
+                UnitAction ua = UnitAction.fromActionArray(action, utt, gs, u, maxAttackRadius);
+                // execute the action if the following happens
+                // 1. The selected unit is *not* null.
+                // 2. The unit selected is owned by the current player
+                // 3. The unit is not currently busy (its unit action is null)
+                // int id = (int) u.getID();
+                if (ua.resourceUsage(u, gs.pgs).consistentWith(pa.getResourceUsage(), gs)) {
+                    ResourceUsage ru = ua.resourceUsage(u, gs.pgs);
+                    pa.getResourceUsage().merge(ru);
+                    pa.addUnitAction(u, ua);
+                }
+            }
+        }
+        return new Pair<>(pa, ipas);
     }
 
 

--- a/src/rts/PlayerAction.java
+++ b/src/rts/PlayerAction.java
@@ -448,7 +448,7 @@ public class PlayerAction {
 
         for(int i=0; i<actions.size(1); i++) {
             actions.getSegment(new int[]{clientOffset, i}, action);
-            final Unit u = gs.pgs.getUnitAt(action[0] % gs.pgs.width, action[0] / gs.pgs.width);
+            final Unit u = gs.pgs.getUnitAt(i % gs.pgs.width, i / gs.pgs.width);
             UnitActionAssignment uaa = gs.unitActions.get(u);
             if (u == null) {
                 ipas.numInvalidActionNull += 1;
@@ -459,7 +459,7 @@ public class PlayerAction {
             }
 
             if (u != null && u.getPlayer() == currentPlayer && uaa == null) {
-                UnitAction ua = UnitAction.fromActionArray(action, utt, gs, u, maxAttackRadius);
+                UnitAction ua = UnitAction.fromActionArrayWithOffset(action, utt, gs, u, maxAttackRadius, 0);
                 // execute the action if the following happens
                 // 1. The selected unit is *not* null.
                 // 2. The unit selected is owned by the current player

--- a/src/rts/UnitAction.java
+++ b/src/rts/UnitAction.java
@@ -806,7 +806,20 @@ public class UnitAction {
      * @return
      */
     public static UnitAction fromActionArray(int[] action, UnitTypeTable utt, GameState gs, Unit u, int maxAttackRange) {
-        int actionType = action[1];
+        return fromActionArrayWithOffset(action, utt, gs, u, maxAttackRange, 1);
+    }
+
+    /**
+     * Creates a UnitAction from an action array
+     * expects [x_coordinate(x) * y_coordinate(y), a_t(6), p_move(4), p_harvest(4), p_return(4), p_produce_direction(4), 
+     * p_produce_unit_type(z), p_attack_location_x_coordinate(x) * p_attack_location_y_coordinate(y), frameskip(n)]
+     *
+     * @param o
+     * @param utt
+     * @return
+     */
+    public static UnitAction fromActionArrayWithOffset(int[] action, UnitTypeTable utt, GameState gs, Unit u, int maxAttackRange, int offset) {
+        int actionType = action[0+offset];
         UnitAction ua = new UnitAction(actionType);
         int centerCoordinate = maxAttackRange / 2;
         switch (actionType) {
@@ -814,24 +827,24 @@ public class UnitAction {
                 break;
             }
             case TYPE_MOVE: {
-                ua.parameter = action[2];
+                ua.parameter = action[1+offset];
                 break;
             }
             case TYPE_HARVEST: {
-                ua.parameter = action[3];
+                ua.parameter = action[2+offset];
                 break;
             }
             case TYPE_RETURN: {
-                ua.parameter = action[4];
+                ua.parameter = action[3+offset];
                 break;
             }
             case TYPE_PRODUCE: {
-                ua.parameter = action[5];
-                ua.unitType = utt.getUnitType(action[6]);
+                ua.parameter = action[4+offset];
+                ua.unitType = utt.getUnitType(action[5+offset]);
             }
             case TYPE_ATTACK_LOCATION: {
-                int relative_x = (action[7] % maxAttackRange - centerCoordinate);
-                int relative_y = (action[7] / maxAttackRange - centerCoordinate);
+                int relative_x = (action[6+offset] % maxAttackRange - centerCoordinate);
+                int relative_y = (action[6+offset] / maxAttackRange - centerCoordinate);
                 ua.x = u.getX() + relative_x;
                 ua.y = u.getY() + relative_y;
                 break;

--- a/src/rts/UnitAction.java
+++ b/src/rts/UnitAction.java
@@ -14,6 +14,7 @@ import java.util.Random;
 
 import org.jdom.Element;
 import rts.units.*;
+import util.NDBuffer;
 import util.XMLWriter;
 
 /**
@@ -596,6 +597,42 @@ public class UnitAction {
                     int relative_x = ua.x - u.getX();
                     int relative_y = ua.y - u.getY();
                     mask[idxOffset+6+4+4+4+4+utt.getUnitTypes().size()+(centerCoordinate+relative_y)*maxAttackRange+(centerCoordinate+relative_x)] = 1;
+                    break;
+                }
+            }
+        }
+    }
+
+    public static void getValidActionBuffer(Unit u, GameState gs, UnitTypeTable utt, NDBuffer mask, int maxAttackRange, int[] idxOffset) {
+        List<UnitAction> uas = u.getUnitActions(gs);
+        int centerCoordinate = maxAttackRange / 2;
+        for (UnitAction ua:uas) {
+            mask.set(idxOffset, ua.type, 1);
+            switch (ua.type) {
+                case TYPE_NONE: {
+                    break;
+                }
+                case TYPE_MOVE: {
+                    mask.set(idxOffset, 6+ua.parameter, 1);
+                    break;
+                }
+                case TYPE_HARVEST: {
+                    mask.set(idxOffset, 6+4+ua.parameter, 1);
+                    break;
+                }
+                case TYPE_RETURN: {
+                    mask.set(idxOffset, 6+4+4+ua.parameter, 1);
+                    break;
+                }
+                case TYPE_PRODUCE: {
+                    mask.set(idxOffset, 6+4+4+4+ua.parameter, 1);
+                    mask.set(idxOffset, 6+4+4+4+4+ua.unitType.ID, 1);
+                    break;
+                }
+                case TYPE_ATTACK_LOCATION: {
+                    int relative_x = ua.x - u.getX();
+                    int relative_y = ua.y - u.getY();
+                    mask.set(idxOffset, 6+4+4+4+4+utt.getUnitTypes().size()+(centerCoordinate+relative_y)*maxAttackRange+(centerCoordinate+relative_x), 1);
                     break;
                 }
             }

--- a/src/tests/JNIGridnetSharedMemClient.java
+++ b/src/tests/JNIGridnetSharedMemClient.java
@@ -62,7 +62,7 @@ public class JNIGridnetSharedMemClient {
     public int renderTheme = PhysicalGameStatePanel.COLORSCHEME_WHITE;
     public int maxAttackRadius;
     PhysicalGameStateJFrame w;
-    public JNIInterface ai1;
+    public JNIAI ai1;
 
     final int clientOffset;
 
@@ -70,6 +70,7 @@ public class JNIGridnetSharedMemClient {
     final NDBuffer obsBuffer;
     final NDBuffer unitMaskBuffer;
     final NDBuffer actionMaskBuffer;
+    final NDBuffer actionBuffer;
     double[] rewards;
     boolean[] dones;
     Response response;
@@ -77,11 +78,12 @@ public class JNIGridnetSharedMemClient {
     PlayerAction pa2;
 
     public JNIGridnetSharedMemClient(RewardFunctionInterface[] a_rfs, String mapPath, AI a_ai2, UnitTypeTable a_utt, boolean partial_obs,
-            int clientOffset, NDBuffer obsBuffer, NDBuffer unitMaskBuffer, NDBuffer actionMaskBuffer) throws Exception{
+            int clientOffset, NDBuffer obsBuffer, NDBuffer unitMaskBuffer, NDBuffer actionMaskBuffer, NDBuffer actionBuffer) throws Exception{
         this.clientOffset = clientOffset;
         this.obsBuffer = obsBuffer;
         this.unitMaskBuffer = unitMaskBuffer;
         this.actionMaskBuffer = actionMaskBuffer;
+        this.actionBuffer = actionBuffer;
         this.mapPath = mapPath;
         partialObs = partial_obs;
         
@@ -119,7 +121,7 @@ public class JNIGridnetSharedMemClient {
         return data.getData();
     }
 
-    public Response gameStep(int[][] action, int player) throws Exception {
+    public Response gameStep(int player) throws Exception {
         if (partialObs) {
             player1gs = new PartiallyObservableGameState(gs, player);
             player2gs = new PartiallyObservableGameState(gs, 1 - player);
@@ -127,7 +129,7 @@ public class JNIGridnetSharedMemClient {
             player1gs = gs;
             player2gs = gs;
         }
-        pa1 = ai1.getAction(player, player1gs, action);
+        pa1 = ai1.getActionFromBuffer(player, player1gs, clientOffset, actionBuffer);
         pa2 = ai2.getAction(1 - player, player2gs);
         gs.issueSafe(pa1);
         gs.issueSafe(pa2);

--- a/src/tests/JNIGridnetSharedMemClient.java
+++ b/src/tests/JNIGridnetSharedMemClient.java
@@ -1,0 +1,213 @@
+/*
+* To change this template, choose Tools | Templates
+* and open the template in the editor.
+*/
+package tests;
+
+import java.io.Writer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.awt.image.BufferedImage;
+import java.io.StringWriter;
+import java.awt.image.DataBufferByte;
+import java.awt.image.WritableRaster;
+import com.beust.jcommander.Parameter;
+
+import ai.PassiveAI;
+import ai.RandomBiasedAI;
+import ai.RandomNoAttackAI;
+import ai.core.AI;
+import ai.jni.JNIAI;
+import ai.rewardfunction.RewardFunctionInterface;
+import ai.jni.JNIInterface;
+import ai.jni.Response;
+import gui.PhysicalGameStateJFrame;
+import gui.PhysicalGameStatePanel;
+import rts.GameState;
+import rts.PartiallyObservableGameState;
+import rts.PhysicalGameState;
+import rts.PlayerAction;
+import rts.Trace;
+import rts.TraceEntry;
+import rts.UnitAction;
+import rts.UnitActionAssignment;
+import rts.units.Unit;
+import rts.units.UnitTypeTable;
+import util.NDBuffer;
+import weka.core.pmml.jaxbbindings.False;
+
+/**
+ *
+ * Improved performance for JVM <-> NumPy data exchange
+ * with direct buffer (JVM allocated).
+ * 
+ */
+public class JNIGridnetSharedMemClient {
+
+    // Settings
+    public RewardFunctionInterface[] rfs;
+    String micrortsPath;
+    String mapPath;
+    public AI ai2;
+    UnitTypeTable utt;
+    public boolean partialObs = false;
+
+    // Internal State
+    PhysicalGameState pgs;
+    GameState gs;
+    GameState player1gs, player2gs;
+    boolean gameover = false;
+    boolean layerJSON = true;
+    public int renderTheme = PhysicalGameStatePanel.COLORSCHEME_WHITE;
+    public int maxAttackRadius;
+    PhysicalGameStateJFrame w;
+    public JNIInterface ai1;
+
+    final int clientOffset;
+
+    // storage
+    final NDBuffer obsBuffer;
+    final NDBuffer unitMaskBuffer;
+    final NDBuffer actionMaskBuffer;
+    double[] rewards;
+    boolean[] dones;
+    Response response;
+    PlayerAction pa1;
+    PlayerAction pa2;
+
+    public JNIGridnetSharedMemClient(RewardFunctionInterface[] a_rfs, String mapPath, AI a_ai2, UnitTypeTable a_utt, boolean partial_obs,
+            int clientOffset, NDBuffer obsBuffer, NDBuffer unitMaskBuffer, NDBuffer actionMaskBuffer) throws Exception{
+        this.clientOffset = clientOffset;
+        this.obsBuffer = obsBuffer;
+        this.unitMaskBuffer = unitMaskBuffer;
+        this.actionMaskBuffer = actionMaskBuffer;
+        this.mapPath = mapPath;
+        partialObs = partial_obs;
+        
+        rfs = a_rfs;
+        utt = a_utt;
+        pgs = PhysicalGameState.load(mapPath, utt);
+        ai1 = new JNIAI(100, 0, utt);
+        ai2 = a_ai2;
+        if (ai2 == null) {
+            throw new Exception("no ai2 was chosen");
+        }
+
+        // initialize storage
+        rewards = new double[rfs.length];
+        dones = new boolean[rfs.length];
+        response = new Response(null, null, null, null);
+    }
+
+    public byte[] render(boolean returnPixels) throws Exception {
+        if (w==null) {
+            w = PhysicalGameStatePanel.newVisualizer(gs, 640, 640, partialObs, null, renderTheme);
+        }
+        w.setStateCloning(gs);
+        w.repaint();
+
+        if (!returnPixels) {
+            return null;
+        }
+        BufferedImage image = new BufferedImage(w.getWidth(),
+            w.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+            w.paint(image.getGraphics());
+
+        WritableRaster raster = image.getRaster();
+        DataBufferByte data = (DataBufferByte) raster.getDataBuffer();
+        return data.getData();
+    }
+
+    public Response gameStep(int[][] action, int player) throws Exception {
+        if (partialObs) {
+            player1gs = new PartiallyObservableGameState(gs, player);
+            player2gs = new PartiallyObservableGameState(gs, 1 - player);
+        } else {
+            player1gs = gs;
+            player2gs = gs;
+        }
+        pa1 = ai1.getAction(player, player1gs, action);
+        pa2 = ai2.getAction(1 - player, player2gs);
+        gs.issueSafe(pa1);
+        gs.issueSafe(pa2);
+        TraceEntry te  = new TraceEntry(gs.getPhysicalGameState().clone(), gs.getTime());
+        te.addPlayerAction(pa1.clone());
+        te.addPlayerAction(pa2.clone());
+
+        // simulate:
+        gameover = gs.cycle();
+        if (gameover) {
+            // ai1.gameOver(gs.winner());
+            ai2.gameOver(gs.winner());
+        }
+        for (int i = 0; i < rewards.length; i++) {
+            rfs[i].computeReward(player, 1 - player, te, gs);
+            dones[i] = rfs[i].isDone();
+            rewards[i] = rfs[i].getReward();
+        }
+
+        player1gs.getBufferObservation(player, clientOffset, obsBuffer);
+
+        response.set(
+            null,
+            rewards,
+            dones,
+            ai1.computeInfo(player, player2gs));
+        return response;
+    }
+
+    public void getMasks(int player) throws Exception {
+        unitMaskBuffer.resetSegment(new int[]{clientOffset});
+        actionMaskBuffer.resetSegment(new int[]{clientOffset});
+
+        for (int i = 0; i < pgs.getUnits().size(); i++) {
+            Unit u = pgs.getUnits().get(i);
+            UnitActionAssignment uaa = gs.getUnitActions().get(u);
+            if (u.getPlayer() == player && uaa == null) {
+                final int[] idxOffset = new int[]{clientOffset, u.getY(), u.getX()};
+                unitMaskBuffer.set(idxOffset, 1);
+                UnitAction.getValidActionBuffer(u, gs, utt, actionMaskBuffer, maxAttackRadius, idxOffset);
+            }
+        }
+    }
+
+    public String sendUTT() throws Exception {
+        Writer w = new StringWriter();
+        utt.toJSON(w);
+        return w.toString(); // now it works fine
+    }
+
+    public Response reset(int player) throws Exception {
+        ai1.reset();
+        ai2 = ai2.clone();
+        ai2.reset();
+        pgs = PhysicalGameState.load(mapPath, utt);
+        gs = new GameState(pgs, utt);
+        if (partialObs) {
+            player1gs = new PartiallyObservableGameState(gs, player);
+        } else {
+            player1gs = gs;
+        }
+
+        for (int i = 0; i < rewards.length; i++) {
+            rewards[i] = 0;
+            dones[i] = false;
+        }
+
+        player1gs.getBufferObservation(player, clientOffset, obsBuffer);
+
+        response.set(
+            null,
+            rewards,
+            dones,
+            "{}");
+        return response;
+    }
+
+    public void close() throws Exception {
+        if (w!=null) {
+            w.dispose();    
+        }
+    }
+}

--- a/src/tests/JNIGridnetSharedMemClient.java
+++ b/src/tests/JNIGridnetSharedMemClient.java
@@ -68,7 +68,6 @@ public class JNIGridnetSharedMemClient {
 
     // storage
     final NDBuffer obsBuffer;
-    final NDBuffer unitMaskBuffer;
     final NDBuffer actionMaskBuffer;
     final NDBuffer actionBuffer;
     double[] rewards;
@@ -78,10 +77,9 @@ public class JNIGridnetSharedMemClient {
     PlayerAction pa2;
 
     public JNIGridnetSharedMemClient(RewardFunctionInterface[] a_rfs, String mapPath, AI a_ai2, UnitTypeTable a_utt, boolean partial_obs,
-            int clientOffset, NDBuffer obsBuffer, NDBuffer unitMaskBuffer, NDBuffer actionMaskBuffer, NDBuffer actionBuffer) throws Exception{
+            int clientOffset, NDBuffer obsBuffer, NDBuffer actionMaskBuffer, NDBuffer actionBuffer) throws Exception{
         this.clientOffset = clientOffset;
         this.obsBuffer = obsBuffer;
-        this.unitMaskBuffer = unitMaskBuffer;
         this.actionMaskBuffer = actionMaskBuffer;
         this.actionBuffer = actionBuffer;
         this.mapPath = mapPath;
@@ -160,7 +158,6 @@ public class JNIGridnetSharedMemClient {
     }
 
     public void getMasks(int player) throws Exception {
-        unitMaskBuffer.resetSegment(new int[]{clientOffset});
         actionMaskBuffer.resetSegment(new int[]{clientOffset});
 
         for (int i = 0; i < pgs.getUnits().size(); i++) {
@@ -168,7 +165,6 @@ public class JNIGridnetSharedMemClient {
             UnitActionAssignment uaa = gs.getUnitActions().get(u);
             if (u.getPlayer() == player && uaa == null) {
                 final int[] idxOffset = new int[]{clientOffset, u.getY(), u.getX()};
-                unitMaskBuffer.set(idxOffset, 1);
                 UnitAction.getValidActionBuffer(u, gs, utt, actionMaskBuffer, maxAttackRadius, idxOffset);
             }
         }

--- a/src/tests/JNIGridnetSharedMemClientSelfPlay.java
+++ b/src/tests/JNIGridnetSharedMemClientSelfPlay.java
@@ -69,7 +69,6 @@ public class JNIGridnetSharedMemClientSelfPlay {
 
     // storage
     final NDBuffer obsBuffer;
-    final NDBuffer unitMaskBuffer;
     final NDBuffer actionMaskBuffer;
     final NDBuffer actionBuffer;
     double[][] rewards = new double[2][];
@@ -78,10 +77,9 @@ public class JNIGridnetSharedMemClientSelfPlay {
     PlayerAction[] pas = new PlayerAction[2];
 
     public JNIGridnetSharedMemClientSelfPlay(RewardFunctionInterface[] a_rfs, String a_micrortsPath, String a_mapPath, UnitTypeTable a_utt, boolean partial_obs,
-            int clientOffset, NDBuffer obsBuffer, NDBuffer unitMaskBuffer, NDBuffer actionMaskBuffer, NDBuffer actionBuffer) throws Exception{
+            int clientOffset, NDBuffer obsBuffer, NDBuffer actionMaskBuffer, NDBuffer actionBuffer) throws Exception{
         this.clientOffset = clientOffset;
         this.obsBuffer = obsBuffer;
-        this.unitMaskBuffer = unitMaskBuffer;
         this.actionMaskBuffer = actionMaskBuffer;
         this.actionBuffer = actionBuffer;
 
@@ -161,7 +159,6 @@ public class JNIGridnetSharedMemClientSelfPlay {
     }
 
     public void getMasks(int player) throws Exception {
-        unitMaskBuffer.resetSegment(new int[]{clientOffset+player});
         actionMaskBuffer.resetSegment(new int[]{clientOffset+player});
 
         for (int i = 0; i < pgs.getUnits().size(); i++) {
@@ -169,7 +166,6 @@ public class JNIGridnetSharedMemClientSelfPlay {
             UnitActionAssignment uaa = gs.getUnitActions().get(u);
             if (u.getPlayer() == player && uaa == null) {
                 final int[] idxOffset = new int[]{clientOffset+player, u.getY(), u.getX()};
-                unitMaskBuffer.set(idxOffset, 1);
                 UnitAction.getValidActionBuffer(u, gs, utt, actionMaskBuffer, maxAttackRadius, idxOffset);
             }
         }

--- a/src/tests/JNIGridnetSharedMemClientSelfPlay.java
+++ b/src/tests/JNIGridnetSharedMemClientSelfPlay.java
@@ -1,0 +1,214 @@
+package tests;
+
+import java.io.Writer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import javax.swing.plaf.basic.BasicInternalFrameTitlePane.SystemMenuBar;
+
+import java.awt.image.BufferedImage;
+import java.io.StringWriter;
+import java.awt.image.DataBufferByte;
+import java.awt.image.WritableRaster;
+import com.beust.jcommander.Parameter;
+
+import ai.PassiveAI;
+import ai.RandomBiasedAI;
+import ai.RandomNoAttackAI;
+import ai.core.AI;
+import ai.jni.JNIAI;
+import ai.rewardfunction.RewardFunctionInterface;
+import ai.jni.JNIInterface;
+import ai.jni.Response;
+import gui.PhysicalGameStateJFrame;
+import gui.PhysicalGameStatePanel;
+import rts.GameState;
+import rts.PartiallyObservableGameState;
+import rts.PhysicalGameState;
+import rts.PlayerAction;
+import rts.Trace;
+import rts.TraceEntry;
+import rts.UnitAction;
+import rts.UnitActionAssignment;
+import rts.units.Unit;
+import rts.units.UnitTypeTable;
+import weka.core.pmml.jaxbbindings.False;
+
+/**
+ *
+ * Improved performance for JVM <-> NumPy data exchange
+ * with direct buffer (JVM allocated).
+ * 
+ */
+public class JNIGridnetSharedMemClientSelfPlay {
+
+
+    // Settings
+    public RewardFunctionInterface[] rfs;
+    String micrortsPath;
+    String mapPath;
+    public AI ai2;
+    UnitTypeTable utt;
+    boolean partialObs = false;
+
+    // Internal State
+    PhysicalGameStateJFrame w;
+    public JNIInterface[] ais = new JNIInterface[2];
+    PhysicalGameState pgs;
+    GameState gs;
+    GameState[] playergs = new GameState[2];
+    boolean gameover = false;
+    boolean layerJSON = true;
+    public int renderTheme = PhysicalGameStatePanel.COLORSCHEME_WHITE;
+    public int maxAttackRadius;
+    public int numPlayers = 2;
+
+    final int clientOffset;
+
+    // storage
+    final NDBuffer obsBuffer;
+    final NDBuffer unitMaskBuffer;
+    final NDBuffer actionMaskBuffer;
+    double[][] rewards = new double[2][];
+    boolean[][] dones = new boolean[2][];
+    Response[] response = new Response[2];
+    PlayerAction[] pas = new PlayerAction[2];
+
+    public JNIGridnetSharedMemClientSelfPlay(RewardFunctionInterface[] a_rfs, String a_micrortsPath, String a_mapPath, UnitTypeTable a_utt, boolean partial_obs,
+            int clientOffset, NDBuffer obsBuffer, NDBuffer unitMaskBuffer, NDBuffer actionMaskBuffer) throws Exception{
+        this.clientOffset = clientOffset;
+        this.obsBuffer = obsBuffer;
+        this.unitMaskBuffer = unitMaskBuffer;
+        this.actionMaskBuffer = actionMaskBuffer;
+
+        micrortsPath = a_micrortsPath;
+        mapPath = a_mapPath;
+        rfs = a_rfs;
+        utt = a_utt;
+        partialObs = partial_obs;
+        maxAttackRadius = utt.getMaxAttackRange() * 2 + 1;
+        if (micrortsPath.length() != 0) {
+            this.mapPath = Paths.get(micrortsPath, mapPath).toString();
+        }
+
+        pgs = PhysicalGameState.load(mapPath, utt);
+
+        // initialize storage
+        for (int i = 0; i < numPlayers; i++) {
+            ais[i] = new JNIAI(100, 0, utt);
+            rewards[i] = new double[rfs.length];
+            dones[i] = new boolean[rfs.length];
+            response[i] = new Response(null, null, null, null);
+        }
+    }
+
+    public byte[] render(boolean returnPixels) throws Exception {
+        if (w==null) {
+            w = PhysicalGameStatePanel.newVisualizer(gs, 640, 640, partialObs, null, renderTheme);
+        }
+        w.setStateCloning(gs);
+        w.repaint();
+
+        if (!returnPixels) {
+            return null;
+        }
+        BufferedImage image = new BufferedImage(w.getWidth(),
+            w.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+            w.paint(image.getGraphics());
+
+        WritableRaster raster = image.getRaster();
+        DataBufferByte data = (DataBufferByte) raster.getDataBuffer();
+        return data.getData();
+    }
+
+    public void gameStep(int[][] action1, int[][] action2) throws Exception {
+        TraceEntry te  = new TraceEntry(gs.getPhysicalGameState().clone(), gs.getTime());
+        for (int i = 0; i < numPlayers; i++) {
+            playergs[i] = gs;
+            if (partialObs) {
+                playergs[i] = new PartiallyObservableGameState(gs, i);
+            }
+            pas[i] = i == 0 ? ais[i].getAction(i, playergs[0], action1) : ais[i].getAction(i, playergs[1], action2);
+            gs.issueSafe(pas[i]);
+            te.addPlayerAction(pas[i].clone());
+        }
+        // simulate:
+        gameover = gs.cycle();
+        if (gameover) {
+            // ai1.gameOver(gs.winner());
+            // ai2.gameOver(gs.winner());
+        }
+
+        for (int i = 0; i < numPlayers; i++) {
+            for (int j = 0; j < rfs.length; j++) {
+                rfs[j].computeReward(i, 1 - i, te, gs);
+                rewards[i][j] = rfs[j].getReward();
+                dones[i][j] = rfs[j].isDone();
+            }
+
+            playergs[i].getBufferObservation(i, clientOffset+i, obsBuffer);
+
+            response[i].set(
+                null,
+                rewards[i],
+                dones[i],
+                "{}");
+        }
+    }
+
+    public void getMasks(int player) throws Exception {
+        unitMaskBuffer.resetSegment(new int[]{clientOffset+player});
+        actionMaskBuffer.resetSegment(new int[]{clientOffset+player});
+
+        for (int i = 0; i < pgs.getUnits().size(); i++) {
+            Unit u = pgs.getUnits().get(i);
+            UnitActionAssignment uaa = gs.getUnitActions().get(u);
+            if (u.getPlayer() == player && uaa == null) {
+                final int[] idxOffset = new int[]{clientOffset+player, u.getY(), u.getX()};
+                unitMaskBuffer.set(idxOffset, 1);
+                UnitAction.getValidActionBuffer(u, gs, utt, actionMaskBuffer, maxAttackRadius, idxOffset);
+            }
+        }
+    }
+
+    public String sendUTT() throws Exception {
+        Writer w = new StringWriter();
+        utt.toJSON(w);
+        return w.toString(); // now it works fine
+    }
+
+    public void reset() throws Exception {
+        pgs = PhysicalGameState.load(mapPath, utt);
+        gs = new GameState(pgs, utt);
+        for (int i = 0; i < numPlayers; i++) {
+            playergs[i] = gs;
+            if (partialObs) {
+                playergs[i] = new PartiallyObservableGameState(gs, i);
+            }
+            ais[i].reset();
+            for (int j = 0; j < rewards.length; j++) {
+                rewards[i][j] = 0;
+                dones[i][j] = false;
+            }
+
+            playergs[i].getBufferObservation(i, clientOffset+i, obsBuffer);
+
+            response[i].set(
+                null,
+                rewards[i],
+                dones[i],
+                "{}");
+        }
+    }
+
+    public Response getResponse(int player) {
+        return response[player];
+    }
+
+    public void close() throws Exception {
+        if (w!=null) {
+            w.dispose();    
+        }
+    }
+}

--- a/src/tests/JNIGridnetSharedMemClientSelfPlay.java
+++ b/src/tests/JNIGridnetSharedMemClientSelfPlay.java
@@ -33,6 +33,7 @@ import rts.UnitAction;
 import rts.UnitActionAssignment;
 import rts.units.Unit;
 import rts.units.UnitTypeTable;
+import util.NDBuffer;
 import weka.core.pmml.jaxbbindings.False;
 
 /**

--- a/src/tests/JNIGridnetSharedMemVecClient.java
+++ b/src/tests/JNIGridnetSharedMemVecClient.java
@@ -50,6 +50,9 @@ import tests.JNIGridnetClientSelfPlay;
  * 
  */
 public class JNIGridnetSharedMemVecClient {
+
+    public static final int ACTION_DIM = 7;
+
     public final JNIGridnetSharedMemClient[] clients;
     public final JNIGridnetSharedMemClientSelfPlay[] selfPlayClients;
     public final int maxSteps;
@@ -63,6 +66,7 @@ public class JNIGridnetSharedMemVecClient {
     final NDBuffer obsBuffer;
     final NDBuffer unitMaskBuffer;
     final NDBuffer actionMaskBuffer;
+    final NDBuffer actionBuffer;
     final double[][] reward;
     final boolean[][] done;
     final Response[] rs;
@@ -72,7 +76,8 @@ public class JNIGridnetSharedMemVecClient {
 
     public JNIGridnetSharedMemVecClient(int a_num_selfplayenvs, int a_num_envs, int a_max_steps, RewardFunctionInterface[] a_rfs,
             String a_micrortsPath, String mapPath, AI[] a_ai2s, UnitTypeTable a_utt, boolean partial_obs,
-            IntBuffer obsBuffer, IntBuffer unitMaskBuffer, IntBuffer actionMaskBuffer, int threadPoolSize) throws Exception {
+            IntBuffer obsBuffer, IntBuffer unitMaskBuffer, IntBuffer actionMaskBuffer, IntBuffer actionBuffer,
+            int threadPoolSize) throws Exception {
         maxSteps = a_max_steps;
         utt = a_utt;
         rfs = a_rfs;
@@ -90,6 +95,7 @@ public class JNIGridnetSharedMemVecClient {
         this.obsBuffer = new NDBuffer(obsBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), GameState.numFeaturePlanes});
         this.unitMaskBuffer = new NDBuffer(unitMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth()});
         this.actionMaskBuffer = new NDBuffer(actionMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), actionMaskNumEntries});
+        this.actionBuffer = new NDBuffer(actionBuffer, new int[]{s1, pgs.getHeight() * pgs.getWidth(), 1+ACTION_DIM});
 
         // initialize clients
         envSteps = new int[a_num_selfplayenvs + a_num_envs];
@@ -97,13 +103,13 @@ public class JNIGridnetSharedMemVecClient {
         for (int i = 0; i < selfPlayClients.length; i++) {
             int clientOffset = i*2;
             selfPlayClients[i] = new JNIGridnetSharedMemClientSelfPlay(a_rfs, a_micrortsPath, mapPath, a_utt, partialObs,
-                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer);
+                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer, this.actionBuffer);
         }
         clients = new JNIGridnetSharedMemClient[a_num_envs];
         for (int i = 0; i < clients.length; i++) {
             int clientOffset = i+selfPlayClients.length*2;
             clients[i] = new JNIGridnetSharedMemClient(a_rfs, this.mapPath, a_ai2s[i], a_utt, partialObs,
-                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer);
+                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer, this.actionBuffer);
         }
 
         // initialize storage
@@ -137,9 +143,9 @@ public class JNIGridnetSharedMemVecClient {
         return responses;
     }
 
-    public Responses gameStep(int[][][] action, int[] players) throws Exception {
+    public Responses gameStep(int[] players) throws Exception {
         for (int i = 0; i < selfPlayClients.length; i++) {
-            selfPlayClients[i].gameStep(action[i*2], action[i*2+1]);
+            selfPlayClients[i].gameStep();
             rs[i*2] = selfPlayClients[i].getResponse(0);
             rs[i*2+1] = selfPlayClients[i].getResponse(1);
             envSteps[i*2] += 1;
@@ -162,8 +168,9 @@ public class JNIGridnetSharedMemVecClient {
                 final int playerInd = i;
                 stepRequests.add(() -> {
                     try {
-                        return clients[clientInd].gameStep(action[playerInd], players[playerInd]);
+                        return clients[clientInd].gameStep(players[playerInd]);
                     } catch (Exception e) {
+                        e.printStackTrace();
                         // xxx(okachiaev): likely need log it here
                         // not sure what is the best cource of actions here
                         return new Response(null, null, null, null);
@@ -177,7 +184,7 @@ public class JNIGridnetSharedMemVecClient {
         for (int i = selfPlayClients.length*2; i < players.length; i++) {
             envSteps[i] += 1;
             if (null == stepResults) {
-                rs[i] = clients[i-selfPlayClients.length*2].gameStep(action[i], players[i]);
+                rs[i] = clients[i-selfPlayClients.length*2].gameStep(players[i]);
             } else {
                 rs[i] = stepResults.get(i-selfPlayClients.length*2).get();
             }

--- a/src/tests/JNIGridnetSharedMemVecClient.java
+++ b/src/tests/JNIGridnetSharedMemVecClient.java
@@ -64,7 +64,6 @@ public class JNIGridnetSharedMemVecClient {
 
     // storage
     final NDBuffer obsBuffer;
-    final NDBuffer unitMaskBuffer;
     final NDBuffer actionMaskBuffer;
     final NDBuffer actionBuffer;
     final double[][] reward;
@@ -76,7 +75,7 @@ public class JNIGridnetSharedMemVecClient {
 
     public JNIGridnetSharedMemVecClient(int a_num_selfplayenvs, int a_num_envs, int a_max_steps, RewardFunctionInterface[] a_rfs,
             String a_micrortsPath, String mapPath, AI[] a_ai2s, UnitTypeTable a_utt, boolean partial_obs,
-            IntBuffer obsBuffer, IntBuffer unitMaskBuffer, IntBuffer actionMaskBuffer, IntBuffer actionBuffer,
+            IntBuffer obsBuffer, IntBuffer actionMaskBuffer, IntBuffer actionBuffer,
             int threadPoolSize) throws Exception {
         maxSteps = a_max_steps;
         utt = a_utt;
@@ -93,7 +92,6 @@ public class JNIGridnetSharedMemVecClient {
 
         // initialize shared storage
         this.obsBuffer = new NDBuffer(obsBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), GameState.numFeaturePlanes});
-        this.unitMaskBuffer = new NDBuffer(unitMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth()});
         this.actionMaskBuffer = new NDBuffer(actionMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), actionMaskNumEntries});
         this.actionBuffer = new NDBuffer(actionBuffer, new int[]{s1, pgs.getHeight() * pgs.getWidth(), ACTION_DIM});
 
@@ -103,13 +101,13 @@ public class JNIGridnetSharedMemVecClient {
         for (int i = 0; i < selfPlayClients.length; i++) {
             int clientOffset = i*2;
             selfPlayClients[i] = new JNIGridnetSharedMemClientSelfPlay(a_rfs, a_micrortsPath, mapPath, a_utt, partialObs,
-                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer, this.actionBuffer);
+                clientOffset, this.obsBuffer, this.actionMaskBuffer, this.actionBuffer);
         }
         clients = new JNIGridnetSharedMemClient[a_num_envs];
         for (int i = 0; i < clients.length; i++) {
             int clientOffset = i+selfPlayClients.length*2;
             clients[i] = new JNIGridnetSharedMemClient(a_rfs, this.mapPath, a_ai2s[i], a_utt, partialObs,
-                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer, this.actionBuffer);
+                clientOffset, this.obsBuffer, this.actionMaskBuffer, this.actionBuffer);
         }
 
         // initialize storage

--- a/src/tests/JNIGridnetSharedMemVecClient.java
+++ b/src/tests/JNIGridnetSharedMemVecClient.java
@@ -56,7 +56,7 @@ public class JNIGridnetSharedMemVecClient {
     public final int[] envSteps; 
     public final RewardFunctionInterface[] rfs;
     public final UnitTypeTable utt;
-    public final boolean partialObs = false;
+    public final boolean partialObs;
     public final String mapPath;
 
     // storage
@@ -94,7 +94,7 @@ public class JNIGridnetSharedMemVecClient {
         selfPlayClients = new JNIGridnetSharedMemClientSelfPlay[a_num_selfplayenvs/2];
         for (int i = 0; i < selfPlayClients.length; i++) {
             int clientOffset = i*2;
-            selfPlayClients[i] = new JNIGridnetSharedMemClientSelfPlay(a_rfs, a_micrortsPath, mapPath, a_utt, partialObs
+            selfPlayClients[i] = new JNIGridnetSharedMemClientSelfPlay(a_rfs, a_micrortsPath, mapPath, a_utt, partialObs,
                 clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer);
         }
         clients = new JNIGridnetSharedMemClient[a_num_envs];

--- a/src/tests/JNIGridnetSharedMemVecClient.java
+++ b/src/tests/JNIGridnetSharedMemVecClient.java
@@ -95,7 +95,7 @@ public class JNIGridnetSharedMemVecClient {
         this.obsBuffer = new NDBuffer(obsBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), GameState.numFeaturePlanes});
         this.unitMaskBuffer = new NDBuffer(unitMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth()});
         this.actionMaskBuffer = new NDBuffer(actionMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), actionMaskNumEntries});
-        this.actionBuffer = new NDBuffer(actionBuffer, new int[]{s1, pgs.getHeight() * pgs.getWidth(), 1+ACTION_DIM});
+        this.actionBuffer = new NDBuffer(actionBuffer, new int[]{s1, pgs.getHeight() * pgs.getWidth(), ACTION_DIM});
 
         // initialize clients
         envSteps = new int[a_num_selfplayenvs + a_num_envs];

--- a/src/tests/JNIGridnetSharedMemVecClient.java
+++ b/src/tests/JNIGridnetSharedMemVecClient.java
@@ -1,0 +1,187 @@
+/*
+* To change this template, choose Tools | Templates
+* and open the template in the editor.
+*/
+package tests;
+
+import java.io.Writer;
+import java.nio.file.Paths;
+import java.nio.IntBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.awt.image.BufferedImage;
+import java.io.StringWriter;
+import java.awt.image.DataBufferByte;
+import java.awt.image.WritableRaster;
+
+import ai.PassiveAI;
+import ai.RandomBiasedAI;
+import ai.RandomNoAttackAI;
+import ai.core.AI;
+import ai.jni.JNIAI;
+import ai.rewardfunction.RewardFunctionInterface;
+import ai.jni.JNIInterface;
+import ai.jni.Response;
+import ai.jni.Responses;
+import gui.PhysicalGameStateJFrame;
+import gui.PhysicalGameStatePanel;
+import rts.GameState;
+import rts.PhysicalGameState;
+import rts.Player;
+import rts.PlayerAction;
+import rts.Trace;
+import rts.TraceEntry;
+import rts.UnitAction;
+import rts.UnitActionAssignment;
+import rts.units.Unit;
+import rts.units.UnitTypeTable;
+import util.NDBuffer;
+import tests.JNIGridnetClientSelfPlay;
+
+/**
+ *
+ * Improved performance for JVM <-> NumPy data exchange
+ * with direct buffer (JVM allocated).
+ * 
+ */
+public class JNIGridnetSharedMemVecClient {
+    public final JNIGridnetSharedMemClient[] clients;
+    public final JNIGridnetSharedMemClientSelfPlay[] selfPlayClients;
+    public final int maxSteps;
+    public final int[] envSteps; 
+    public final RewardFunctionInterface[] rfs;
+    public final UnitTypeTable utt;
+    public final boolean partialObs = false;
+    public final String mapPath;
+
+    // storage
+    final NDBuffer obsBuffer;
+    final NDBuffer unitMaskBuffer;
+    final NDBuffer actionMaskBuffer;
+    final double[][] reward;
+    final boolean[][] done;
+    final Response[] rs;
+    final Responses responses;
+
+    public JNIGridnetSharedMemVecClient(int a_num_selfplayenvs, int a_num_envs, int a_max_steps, RewardFunctionInterface[] a_rfs,
+            String a_micrortsPath, String mapPath, AI[] a_ai2s, UnitTypeTable a_utt, boolean partial_obs,
+            IntBuffer obsBuffer, IntBuffer unitMaskBuffer, IntBuffer actionMaskBuffer) throws Exception {
+        maxSteps = a_max_steps;
+        utt = a_utt;
+        rfs = a_rfs;
+        partialObs = partial_obs;
+
+        this.mapPath = Paths.get(a_micrortsPath, mapPath).toString();
+
+        // get dims
+        final PhysicalGameState pgs = PhysicalGameState.load(this.mapPath, utt);
+        final int s1 = a_num_selfplayenvs + a_num_envs;
+        final int maxAttackRadius = utt.getMaxAttackRange() * 2 + 1;
+        final int actionMaskNumEntries = 6+4+4+4+4+utt.getUnitTypes().size()+maxAttackRadius*maxAttackRadius;
+
+        // initialize shared storage
+        this.obsBuffer = new NDBuffer(obsBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), GameState.numFeaturePlanes});
+        this.unitMaskBuffer = new NDBuffer(unitMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth()});
+        this.actionMaskBuffer = new NDBuffer(actionMaskBuffer, new int[]{s1, pgs.getHeight(), pgs.getWidth(), actionMaskNumEntries});
+
+        // initialize clients
+        envSteps = new int[a_num_selfplayenvs + a_num_envs];
+        selfPlayClients = new JNIGridnetSharedMemClientSelfPlay[a_num_selfplayenvs/2];
+        for (int i = 0; i < selfPlayClients.length; i++) {
+            int clientOffset = i*2;
+            selfPlayClients[i] = new JNIGridnetSharedMemClientSelfPlay(a_rfs, a_micrortsPath, mapPath, a_utt, partialObs
+                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer);
+        }
+        clients = new JNIGridnetSharedMemClient[a_num_envs];
+        for (int i = 0; i < clients.length; i++) {
+            int clientOffset = i+selfPlayClients.length*2;
+            clients[i] = new JNIGridnetSharedMemClient(a_rfs, this.mapPath, a_ai2s[i], a_utt, partialObs,
+                clientOffset, this.obsBuffer, this.unitMaskBuffer, this.actionMaskBuffer);
+        }
+
+        // initialize storage
+        reward = new double[s1][rfs.length];
+        done = new boolean[s1][rfs.length];
+        responses = new Responses(null, null, null);
+        rs = new Response[s1];
+    }
+
+    public Responses reset(int[] players) throws Exception {
+        for (int i = 0; i < selfPlayClients.length; i++) {
+            selfPlayClients[i].reset();
+            rs[i*2] = selfPlayClients[i].getResponse(0);
+            rs[i*2+1] = selfPlayClients[i].getResponse(1);
+        }
+        for (int i = selfPlayClients.length*2; i < players.length; i++) {
+            rs[i] = clients[i-selfPlayClients.length*2].reset(players[i]);
+        }
+
+        for (int i = 0; i < rs.length; i++) {
+            reward[i] = rs[i].reward;
+            done[i] = rs[i].done;
+        }
+        responses.set(null, reward, done);
+        return responses;
+    }
+
+    public Responses gameStep(int[][][] action, int[] players) throws Exception {
+        for (int i = 0; i < selfPlayClients.length; i++) {
+            selfPlayClients[i].gameStep(action[i*2], action[i*2+1]);
+            rs[i*2] = selfPlayClients[i].getResponse(0);
+            rs[i*2+1] = selfPlayClients[i].getResponse(1);
+            envSteps[i*2] += 1;
+            envSteps[i*2+1] += 1;
+            if (rs[i*2].done[0] || envSteps[i*2] >= maxSteps) {
+                selfPlayClients[i].reset();
+                rs[i*2].done[0] = true;
+                rs[i*2+1].done[0] = true;
+                envSteps[i*2] =0;
+                envSteps[i*2+1] =0;
+            }
+        }
+
+        for (int i = selfPlayClients.length*2; i < players.length; i++) {
+            envSteps[i] += 1;
+            rs[i] = clients[i-selfPlayClients.length*2].gameStep(action[i], players[i]);
+            if (rs[i].done[0] || envSteps[i] >= maxSteps) {
+                clients[i-selfPlayClients.length*2].reset(players[i]);
+                rs[i].done[0] = true;
+                envSteps[i] = 0;
+            }
+        }
+        for (int i = 0; i < rs.length; i++) {
+            reward[i] = rs[i].reward;
+            done[i] = rs[i].done;
+        }
+        responses.set(null, reward, done);
+        return responses;
+    }
+
+    public void getMasks(int player) throws Exception {
+        for (int i = 0; i < selfPlayClients.length; i++) {
+            selfPlayClients[i].getMasks(0);
+            selfPlayClients[i].getMasks(1);
+        }
+        for (int i = 0; i < clients.length; i++) {
+            clients[i].getMasks(player);
+        }
+    }
+
+    public void close() throws Exception {
+        if (clients != null) {
+            for (JNIGridnetSharedMemClient client: clients) {
+                client.close();
+            }
+        }
+        if (selfPlayClients != null) {
+            for (JNIGridnetSharedMemClientSelfPlay client: selfPlayClients) {
+                client.close();
+            }
+        }
+    }
+}

--- a/src/tests/NDBufferTest.java
+++ b/src/tests/NDBufferTest.java
@@ -1,0 +1,41 @@
+package tests;
+
+import java.nio.IntBuffer;
+import java.util.Arrays;
+
+import util.NDBuffer;
+
+public class NDBufferTest {
+
+    private static int sumBuffer(NDBuffer buffer) {
+        final IntBuffer buff = buffer.getBuffer();
+        buff.rewind();
+        int total = 0;
+        while(buff.hasRemaining()) {
+            total += buff.get();
+        }
+        return total;
+    }
+
+    public static void main(String[] args) {
+        final int capacity = 2 * 2 * 3;
+        final IntBuffer buff = IntBuffer.allocate(capacity);
+        final NDBuffer ndbuff = new NDBuffer(buff, new int[]{2, 2, 3});
+        
+        assert sumBuffer(ndbuff) == 0;
+
+        ndbuff.set(new int[]{0, 1, 0}, 100);
+        ndbuff.set(new int[]{1, 1, 0}, 10);
+        ndbuff.set(new int[]{1, 1, 1}, 20);
+        ndbuff.set(new int[]{1, 1, 2}, 30);
+
+        System.out.println(Arrays.toString(ndbuff.getBuffer().array()));
+        assert sumBuffer(ndbuff) == 160;
+
+        ndbuff.resetSegment(new int[]{1, 1});
+
+        System.out.println(Arrays.toString(ndbuff.getBuffer().array()));
+        assert sumBuffer(ndbuff) == 100;
+    }
+    
+}

--- a/src/tests/NDBufferTest.java
+++ b/src/tests/NDBufferTest.java
@@ -36,6 +36,10 @@ public class NDBufferTest {
 
         System.out.println(Arrays.toString(ndbuff.getBuffer().array()));
         assert sumBuffer(ndbuff) == 100;
+
+        final int[] dest = new int[3];
+        ndbuff.getSegment(new int[]{0, 1}, dest);
+        System.out.println(Arrays.toString(dest));
     }
     
 }

--- a/src/util/NDBuffer.java
+++ b/src/util/NDBuffer.java
@@ -47,6 +47,17 @@ public class NDBuffer {
         }
     }
 
+    public void getSegment(int[] segment, int[] dest) {
+        int offset = 0;
+        for (int i = 0; i < segment.length; i++) {
+            offset += segment[i] * offsets[i];
+        }
+
+        for (int pos = 0; pos < offsets[segment.length-1]; pos++) {
+            dest[pos] = buffer.get(offset+pos);
+        }
+    }
+
     public void set(int[] point, int value) {
         this.set(point, 0, value);
     }
@@ -61,6 +72,10 @@ public class NDBuffer {
 
     public IntBuffer getBuffer() {
         return this.buffer;
+    }
+
+    public int size(int pos) {
+        return dims[pos];
     }
 
 }

--- a/src/util/NDBuffer.java
+++ b/src/util/NDBuffer.java
@@ -1,0 +1,66 @@
+package util;
+
+import java.nio.IntBuffer;
+import java.util.Arrays;
+
+/**
+ * Immitate row-level n-dimensional array layout backed
+ * by a flat buffer.
+ */
+public class NDBuffer {
+
+    private final IntBuffer buffer;
+    private final int numDims;
+    private final int[] dims;
+    private final int[] offsets;
+
+    public NDBuffer(IntBuffer buffer, int[] dims) {
+        this.buffer = buffer;
+        this.dims = dims;
+        this.numDims = dims.length;
+
+        this.offsets = new int[numDims];
+        this.offsets[numDims-1] = 1;
+        if (numDims > 1) {
+            for (int i = numDims-2; i >= 0; i--) {
+                this.offsets[i] = this.offsets[i+1]*dims[i+1];
+            }
+        }
+    }
+
+    /**
+     * Set all values in tail-ordered block to 0.
+     */
+    public void resetSegment(int[] segment) {
+        int offset = 0;
+        for (int i = 0; i < segment.length; i++) {
+            offset += segment[i] * offsets[i];
+        }
+
+        if (buffer.hasArray()) {
+            final int bufferOffset = buffer.arrayOffset();
+            Arrays.fill(buffer.array(), offset+bufferOffset, offset+bufferOffset+offsets[segment.length-1], 0);
+        } else {
+            for (int pos = 0; pos < offsets[segment.length-1]; pos++) {
+                buffer.put(offset+pos, 0);
+            }
+        }
+    }
+
+    public void set(int[] point, int value) {
+        this.set(point, 0, value);
+    }
+
+    public void set(int[] point, int segmentPos, int value) {
+        int pos = segmentPos;
+        for (int i = 0; i < point.length; i++) {
+            pos += point[i] * offsets[i];
+        }
+        buffer.put(pos, value);
+    }
+
+    public IntBuffer getBuffer() {
+        return this.buffer;
+    }
+
+}


### PR DESCRIPTION
This is the first part of the PR, another one will be done for Python project separately (submodule needs to be updated first).

PR introduces new set of `SharedMem` JNI clients that take `IntBuffer`s for obs, unit masks, and actions masks. Rather than returning those from function calls as native `int[]` arrays, clients update data in-place. `NDBuffer` is just a convenient wrapper to hide quite a lot of offsets calculations.

The idea is the following:
* CPython allocates `bytebuffer` with the capacity requires for storing entire `ndarray`
* buffer is converted into directly allocated `java.nio.IntBuffer` on JVM
* `np.asarray` is used to map the same buffer to NumPy array with further taking view onto the same memory with `.reshape` 

Now both CPython and JVM can exchange data between runtimes without any mem copy operations. Profiling before and after the change is done:

```
Before the change:

         5214440 function calls (5210344 primitive calls) in 38.373 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     4096   14.419    0.004   32.318    0.008 vec_env.py:161(step_wait)
    98304    4.061    0.000    7.997    0.000 vec_env.py:136(_encode_obs)
     4096    2.126    0.001    5.373    0.001 vec_env.py:146(step_async)
   208994    9.132    0.000    9.132    0.000 {built-in method numpy.array}


After the change:

         1955869 function calls (1951773 primitive calls) in 22.445 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     4096   15.620    0.004   15.980    0.004 vec_env2.py:184(step_wait)

Masks, before the change:

         992307 function calls (990003 primitive calls) in 12.858 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      768    0.281    0.000    5.841    0.008 vec_env.py:196(get_action_mask)
    39940    7.300    0.000    7.300    0.000 {built-in method numpy.array}

Masks, after the change:

         378698 function calls (376394 primitive calls) in 5.340 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      768    0.878    0.001    0.878    0.001 vec_env2.py:250(get_action_mask)
     1538    0.069    0.000    0.069    0.000 {built-in method numpy.array}
```

Both changes together yields 2.5x speedup (even larger when running more clients within same `VecClient` instance).

Note, that memory allocation is done on CPython side because CPython runtime lives longer than JVM's. So the allocation has to be done this way to avoid mem corruption when JVM finalizer are called on JVM shutdown.