### PR TITLE
Improved threading on JVM side using CountDownLatch-based synchronization

### DIFF
--- a/src/tests/JNIClientThreadSync.java
+++ b/src/tests/JNIClientThreadSync.java
@@ -1,6 +1,7 @@
 package tests;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Utility class to carry synchronization locks to run vec env
@@ -9,6 +10,7 @@ import java.util.concurrent.CountDownLatch;
 public class JNIClientThreadSync {
 
     public static enum OpType {
+        NOOP,
         STEP,
         MASKS,
         SHUTDOWN,
@@ -16,16 +18,32 @@ public class JNIClientThreadSync {
 
     final CountDownLatch blocker;
     final CountDownLatch ready;
-    final OpType op;
+    final AtomicReference<OpType> nextOp;
 
-    private JNIClientThreadSync(CountDownLatch blocker, CountDownLatch ready, OpType op) {
+    private JNIClientThreadSync(CountDownLatch blocker, CountDownLatch ready, AtomicReference<OpType> nextOp) {
         this.blocker = blocker;
         this.ready = ready;
-        this.op = op;
+        this.nextOp = nextOp;
     }
 
-    public final static JNIClientThreadSync forClients(int numClients, OpType op) {
-        return new JNIClientThreadSync(new CountDownLatch(1), new CountDownLatch(numClients), op);
+    public final static JNIClientThreadSync forClients(int numClients) {
+        final AtomicReference<OpType> nextOp = new AtomicReference<>(OpType.NOOP);
+        return new JNIClientThreadSync(new CountDownLatch(1), new CountDownLatch(numClients), nextOp);
+    }
+
+    public final static void executeOn(AtomicReference<JNIClientThreadSync> ref, OpType op, int numClients) {
+        // replace sync object for the next cycle
+        final JNIClientThreadSync currentSync = ref.getAndSet(forClients(numClients));
+
+        currentSync.setNextOpType(op);
+        // let all threads run
+        currentSync.getBlockerLock().countDown();
+        try {
+            // wait for all threads to finish
+            currentSync.getReadyLock().await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Sync thread was interrupted.");
+        }
     }
 
     public CountDownLatch getBlockerLock() {
@@ -36,8 +54,12 @@ public class JNIClientThreadSync {
         return this.ready;
     }
 
-    public OpType getOpType() {
-        return this.op;
+    public OpType getNextOpType() {
+        return this.nextOp.get();
+    }
+
+    public void setNextOpType(OpType op) {
+        this.nextOp.set(op);
     }
 
 }

--- a/src/tests/JNIClientThreadSync.java
+++ b/src/tests/JNIClientThreadSync.java
@@ -1,0 +1,43 @@
+package tests;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Utility class to carry synchronization locks to run vec env
+ * clients on separate threads
+ */
+public class JNIClientThreadSync {
+
+    public static enum OpType {
+        STEP,
+        MASKS,
+        SHUTDOWN,
+    }
+
+    final CountDownLatch blocker;
+    final CountDownLatch ready;
+    final OpType op;
+
+    private JNIClientThreadSync(CountDownLatch blocker, CountDownLatch ready, OpType op) {
+        this.blocker = blocker;
+        this.ready = ready;
+        this.op = op;
+    }
+
+    public final static JNIClientThreadSync forClients(int numClients, OpType op) {
+        return new JNIClientThreadSync(new CountDownLatch(1), new CountDownLatch(numClients), op);
+    }
+
+    public CountDownLatch getBlockerLock() {
+        return this.blocker;
+    }
+
+    public CountDownLatch getReadyLock() {
+        return this.ready;
+    }
+
+    public OpType getOpType() {
+        return this.op;
+    }
+
+}

--- a/src/tests/JNIGridnetSharedMemClient.java
+++ b/src/tests/JNIGridnetSharedMemClient.java
@@ -210,6 +210,9 @@ public class JNIGridnetSharedMemClient implements Runnable {
         }
     }
 
+    // xxx(okachaiev): the overlap between this code and the code in
+    // selfplay client is quite large. i would rather refactor this to
+    // be shared (either as a parent class or as a wrapper)
     @Override
     public void run() {
         JNIClientThreadSync clientSync = null;
@@ -219,7 +222,10 @@ public class JNIGridnetSharedMemClient implements Runnable {
             try {
                 clientSync = clientSyncRef.get();
                 clientSync.getBlockerLock().await();
-                switch (clientSync.getOpType()) {
+                switch (clientSync.getNextOpType()) {
+                    case NOOP:
+                        break;
+
                     case STEP:
                         gameStep(0);
                         break;
@@ -235,11 +241,11 @@ public class JNIGridnetSharedMemClient implements Runnable {
                 }
             } catch(InterruptedException e) {
                 // no-op
-                // xxx(okachaiev): very wrong!
+                // xxx(okachaiev): is this the right thing to do?
                 running = false;
             } catch(Exception e) {
                 e.printStackTrace();
-                // xxx(okachaiev): again no op?
+                // xxx(okachaiev): is this the right thing to do?
             } finally {
                 if (null != clientSync) {
                     clientSync.getReadyLock().countDown();

--- a/src/tests/JNIGridnetSharedMemClientSelfPlay.java
+++ b/src/tests/JNIGridnetSharedMemClientSelfPlay.java
@@ -209,7 +209,10 @@ public class JNIGridnetSharedMemClientSelfPlay implements Runnable {
             try {
                 clientSync = clientSyncRef.get();
                 clientSync.getBlockerLock().await();
-                switch (clientSync.getOpType()) {
+                switch (clientSync.getNextOpType()) {
+                    case NOOP:
+                        break;
+
                     case STEP:
                         gameStep();
                         break;
@@ -225,11 +228,11 @@ public class JNIGridnetSharedMemClientSelfPlay implements Runnable {
                 }
             } catch(InterruptedException e) {
                 // no-op
-                // xxx(okachaiev): very wrong!
+                // xxx(okachaiev): is this the right thing to do?
                 running = false;
             } catch(Exception e) {
                 e.printStackTrace();
-                // xxx(okachaiev): again no op?
+                // xxx(okachaiev): is this the right thing to do?
             } finally {
                 if (null != clientSync) {
                     clientSync.getReadyLock().countDown();


### PR DESCRIPTION
Using fixed `ExecutorService` for executing game steps (and masks) let us utilize CPU better. But it still has a significant overhead, mainly because of lambda runnables that needs to be allocated and passed around. On top of this, we can't rely on thread-aware allocations to speedup access (e.g. `ThreadLocal`s).

The algorithm presented here works as the following:
* both clients implement `Runnable`, each client is allocated with its own thread
* each thread gets "ready to start" `CountDownLatch`, main thread waits for all of them to start before proceeding
* main thread creates `AtomicReference` with a special `JNIClientThreadSync` object that carries 2 additional latches and atomic reference to the operation that needs to be performed
* each operation (`gameStep`, `getMasks`, `close`) is performed by 1) swapping `JNIClientThreadSync` (for the next cycle), 2) calling `executeOn` for the current value of `JNIClientThreadSync` (see details below)

Run loop of the client:
* deref current `JNIClientThreadSync`
* wait on `blocker` latch
* when released, deref `OpType` that needs to be performed (e.g. `STEP` or `MASKS`)
* execute the operation that was requested
* decrement `ready` latch (this releases main thread)
* repeat until `SHUTDOWN` is requested

How `executeOn` works:
* swap the operation requested in the atomic reference associated with current `JNIClientThreadSync`
* decrement `ready` latch (this releases all clients)
* block on `ready` latch

The key results that I get so far: the env now scales rather well when increasing number of clients. 

Share as a draft. I'm still working on hooking up proper JMX metrics so I can profile Java code better. It seems I can get improvement by moving away from shared arrays for rewards/termination flags (doing the same thing that is done for observations right now).