### PR TITLE
Improve algorithmic complexity of getUnitAt outside of game cycle

### DIFF
--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -30,7 +30,6 @@ public class GameState {
     protected UnitTypeTable utt = null;
 
     protected int [][][][] matrixObservation;
-    protected int[] unitPositionCache;
     public static final int numFeatureMaps = 5;
     public static final int numFeaturePlanes = 27;
 
@@ -532,6 +531,10 @@ public class GameState {
      * @return whether the game was over
      */
     public boolean cycle() {
+        // lock positions cache to make sure that stale caache is
+        // not use during the update
+        pgs.resetUnitPositions();
+
         time++;
         
         List<UnitActionAssignment> readyToExecute = new LinkedList<UnitActionAssignment>();
@@ -548,7 +551,12 @@ public class GameState {
             uaa.action.execute(uaa.unit,this);
         }
         
-        return gameover();
+        boolean go = gameover();
+
+        // recompute caache and let everyone else use it
+        pgs.computeUnitPositions();
+
+        return go;
     }
     
     
@@ -829,17 +837,9 @@ public class GameState {
     | Current Action       | 6      | -, move, harvest, return, produce, attack                |
     */
     public void getBufferObservation(int player, int clientIndex, NDBuffer buffer) {
-        if (unitPositionCache == null) {
-            unitPositionCache = new int[pgs.height*pgs.width];
-        }
-
-        Arrays.fill(unitPositionCache, 0);
         buffer.resetSegment(new int[]{clientIndex});
 
         for (final Unit u: getUnits()) {
-            // mark existing unit
-            unitPositionCache[u.getY()*pgs.width+u.getX()] = 1;
-
             final UnitActionAssignment uaa = unitActions.get(u);
             final int playerOffset = (-1 == u.getPlayer()) ? 0 : 1+((u.getPlayer()+player)%2);
             final int unitActionType = (null == uaa) ? UnitAction.TYPE_NONE : uaa.action.type;
@@ -854,7 +854,7 @@ public class GameState {
         // scan over empty cells
         for (int y=0; y<pgs.getHeight(); y++) {
             for (int x=0; x<pgs.getWidth(); x++) {
-                if (0 == unitPositionCache[y*pgs.width+x]) {
+                if (PhysicalGameState.EMPTY_CELL == pgs.unitPositionCache[y*pgs.width+x]) {
                     buffer.set(new int[]{clientIndex, y, x, 0}, 1);
                     buffer.set(new int[]{clientIndex, y, x, 5}, 1);
                     buffer.set(new int[]{clientIndex, y, x, 10}, 1);
@@ -935,7 +935,7 @@ public class GameState {
             unitActionMatrix
         };
     }
-    
+
     /**
      * Constructs a GameState from XML
      * @param e

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -531,7 +531,7 @@ public class GameState {
      * @return whether the game was over
      */
     public boolean cycle() {
-        // lock positions cache to make sure that stale caache is
+        // lock positions cache to make sure that stale cache is
         // not use during the update
         pgs.resetUnitPositions();
 
@@ -553,7 +553,7 @@ public class GameState {
         
         boolean go = gameover();
 
-        // recompute caache and let everyone else use it
+        // recompute cache and let everyone else use it
         pgs.computeUnitPositions();
 
         return go;

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -45,6 +45,8 @@ public class PhysicalGameState {
      */
     public static final int TERRAIN_WALL = 1;
 
+    public static final int EMPTY_CELL = -1;
+
     int width = 8;
     int height = 8;
     int terrain[] = null;
@@ -60,6 +62,12 @@ public class PhysicalGameState {
      * Matrix shapes
      */
     int[] hitpointsShape;
+
+    /**
+     * Mapping from unit position to unit index
+     */
+    public int[] unitPositionCache;
+    public boolean unitPositionCacheReady = false;
 
     /**
      * Constructs the game state map from a XML
@@ -110,6 +118,7 @@ public class PhysicalGameState {
         height = a_height;
         terrain = t;
         hitpointsShape = new int[]{width, height, 2};
+        unitPositionCache = new int[height*width];
     }
 
     /**
@@ -258,22 +267,39 @@ public class PhysicalGameState {
         return null;
     }
 
+    public void resetUnitPositions() {
+        Arrays.fill(unitPositionCache, EMPTY_CELL);
+        unitPositionCacheReady = false;
+    }
+
+    public void computeUnitPositions() {
+        for (int i=0; i<getUnits().size(); i++) {
+            final Unit u = getUnits().get(i);
+            unitPositionCache[u.getY()*width+u.getX()] = i;
+        }
+        unitPositionCacheReady = true;
+    }
+
     /**
-     * Returns the {@link Unit} at a given coordinate or null if no unit is
-     * present
-     *
-     * @param x
-     * @param y
-     * @return
+     * If the cache is available, the call uses cache of pos -> unit id
+     * rather than scanning over all existing units on the board. If cache
+     * is "loccked", fallsback to existing method. The cache is locked
+     * for the duration of game a cycle.
      */
     public Unit getUnitAt(int x, int y) {
-        for (Unit u : units) {
-            if (u.getX() == x && u.getY() == y) {
-                return u;
+        if (unitPositionCacheReady) {
+            int index = unitPositionCache[y*width+x];
+            return (EMPTY_CELL == index) ? null : getUnits().get(index);
+        } else {
+            for (Unit u : units) {
+                if (u.getX() == x && u.getY() == y) {
+                    return u;
+                }
             }
+            return null;
         }
-        return null;
     }
+
 
     /**
      * Returns the units within a squared area

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -327,7 +327,7 @@ public class PhysicalGameState {
      */
     public Collection<Unit> getUnitsAround(int x, int y, int width, int height) {
         final List<Unit> closeUnits = new LinkedList<Unit>();
-        if (unitPositionCacheReady) {
+        if (unitPositionCacheReady && getUnits().size() > width*height) {
             for (int dx=x-width; dx<=x+width; dx++) {
                 for (int dy=y-height; dy<=y+height; dy++) {
                     final Unit u = getUnitAt(dx, dy);

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -326,10 +326,21 @@ public class PhysicalGameState {
      * @return
      */
     public Collection<Unit> getUnitsAround(int x, int y, int width, int height) {
-        List<Unit> closeUnits = new LinkedList<Unit>();
-        for (Unit u : units) {
-            if ((Math.abs(u.getX() - x) <= width && Math.abs(u.getY() - y) <= height)) {
-                closeUnits.add(u);
+        final List<Unit> closeUnits = new LinkedList<Unit>();
+        if (unitPositionCacheReady) {
+            for (int dx=x-width; dx<=x+width; dx++) {
+                for (int dy=y-height; dy<=y+height; dy++) {
+                    final Unit u = getUnitAt(dx, dy);
+                    if (null != u) {
+                        closeUnits.add(u);
+                    }
+                }
+            }
+        } else {
+            for (Unit u : units) {
+                if ((Math.abs(u.getX() - x) <= width && Math.abs(u.getY() - y) <= height)) {
+                    closeUnits.add(u);
+                }
             }
         }
         return closeUnits;

--- a/src/rts/PhysicalGameState.java
+++ b/src/rts/PhysicalGameState.java
@@ -288,6 +288,9 @@ public class PhysicalGameState {
      */
     public Unit getUnitAt(int x, int y) {
         if (unitPositionCacheReady) {
+            if (x < 0 || y < 0 || x >= width || y >= height) {
+                return null;
+            }
             int index = unitPositionCache[y*width+x];
             return (EMPTY_CELL == index) ? null : getUnits().get(index);
         } else {

--- a/src/rts/UnitAction.java
+++ b/src/rts/UnitAction.java
@@ -534,6 +534,7 @@ public class UnitAction {
     }
 
     public static int[] getValidActionArray(List<UnitAction> uas, GameState gs, UnitTypeTable utt) {
+        int numUnits = utt.getUnitTypes().size();
         int[] validAction = new int[6+4+4+4+4+utt.getUnitTypes().size()+gs.pgs.width*gs.pgs.height];
         for (UnitAction ua:uas) {
             validAction[ua.type] = 1;
@@ -559,7 +560,7 @@ public class UnitAction {
                     break;
                 }
                 case TYPE_ATTACK_LOCATION: {
-                    validAction[6+4+4+4+4+utt.getUnitTypes().size()+ua.y*gs.pgs.width+ua.x] = 1;
+                    validAction[6+4+4+4+4+numUnits+ua.y*gs.pgs.width+ua.x] = 1;
                     break;
                 }
             }
@@ -568,8 +569,9 @@ public class UnitAction {
     }
 
     public static void getValidActionArray(Unit u, GameState gs, UnitTypeTable utt, int[] mask, int maxAttackRange, int idxOffset) {
-        List<UnitAction> uas = u.getUnitActions(gs);
+        final List<UnitAction> uas = u.getUnitActions(gs);
         int centerCoordinate = maxAttackRange / 2;
+        int numUnits = utt.getUnitTypes().size();
         for (UnitAction ua:uas) {
             mask[idxOffset+ua.type] = 1;
             switch (ua.type) {
@@ -596,7 +598,7 @@ public class UnitAction {
                 case TYPE_ATTACK_LOCATION: {
                     int relative_x = ua.x - u.getX();
                     int relative_y = ua.y - u.getY();
-                    mask[idxOffset+6+4+4+4+4+utt.getUnitTypes().size()+(centerCoordinate+relative_y)*maxAttackRange+(centerCoordinate+relative_x)] = 1;
+                    mask[idxOffset+6+4+4+4+4+numUnits+(centerCoordinate+relative_y)*maxAttackRange+(centerCoordinate+relative_x)] = 1;
                     break;
                 }
             }
@@ -604,9 +606,10 @@ public class UnitAction {
     }
 
     public static void getValidActionBuffer(Unit u, GameState gs, UnitTypeTable utt, NDBuffer mask, int maxAttackRange, int[] idxOffset) {
-        List<UnitAction> uas = u.getUnitActions(gs);
+        final List<UnitAction> uas = u.getUnitActions(gs);
         int centerCoordinate = maxAttackRange / 2;
-        for (UnitAction ua:uas) {
+        int numUnits = utt.getUnitTypes().size();
+        for (UnitAction ua: uas) {
             mask.set(idxOffset, ua.type, 1);
             switch (ua.type) {
                 case TYPE_NONE: {
@@ -632,7 +635,7 @@ public class UnitAction {
                 case TYPE_ATTACK_LOCATION: {
                     int relative_x = ua.x - u.getX();
                     int relative_y = ua.y - u.getY();
-                    mask.set(idxOffset, 6+4+4+4+4+utt.getUnitTypes().size()+(centerCoordinate+relative_y)*maxAttackRange+(centerCoordinate+relative_x), 1);
+                    mask.set(idxOffset, 6+4+4+4+4+numUnits+(centerCoordinate+relative_y)*maxAttackRange+(centerCoordinate+relative_x), 1);
                     break;
                 }
             }

--- a/src/rts/units/Unit.java
+++ b/src/rts/units/Unit.java
@@ -337,7 +337,7 @@ public class Unit implements Serializable {
 
         PhysicalGameState pgs = s.getPhysicalGameState();
         Player p = pgs.getPlayer(player);
-        
+
         // retrieves units around me
         final Unit uup = pgs.getUnitAt(x,y-1);
         final Unit uright = pgs.getUnitAt(x+1,y);
@@ -353,6 +353,7 @@ public class Unit implements Serializable {
                 if (x>0 && uleft!=null && uleft.player!=player && uleft.player>=0) l.add(new UnitAction(UnitAction.TYPE_ATTACK_LOCATION,uleft.x,uleft.y));                
             } else {
                 int sqrange = type.attackRange*type.attackRange;
+                // xxx(okachaaiev): this should be replaced as well
                 for(Unit u:pgs.getUnits()) {
                     if (u.player<0 || u.player==player) continue;
                     int sq_dx = (u.x - x)*(u.x - x);
@@ -392,10 +393,10 @@ public class Unit implements Serializable {
                 int tdown = (y<pgs.getHeight()-1 ? pgs.getTerrain(x, y+1):PhysicalGameState.TERRAIN_WALL);
                 int tleft = (x>0 ? pgs.getTerrain(x-1, y):PhysicalGameState.TERRAIN_WALL);
 
-                if (tup==PhysicalGameState.TERRAIN_NONE && pgs.getUnitAt(x,y-1) == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_UP,ut));
-                if (tright==PhysicalGameState.TERRAIN_NONE && pgs.getUnitAt(x+1,y) == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_RIGHT,ut));
-                if (tdown==PhysicalGameState.TERRAIN_NONE && pgs.getUnitAt(x,y+1) == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_DOWN,ut));
-                if (tleft==PhysicalGameState.TERRAIN_NONE && pgs.getUnitAt(x-1,y) == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_LEFT,ut));
+                if (tup==PhysicalGameState.TERRAIN_NONE && uup == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_UP,ut));
+                if (tright==PhysicalGameState.TERRAIN_NONE && uright == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_RIGHT,ut));
+                if (tdown==PhysicalGameState.TERRAIN_NONE && udown == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_DOWN,ut));
+                if (tleft==PhysicalGameState.TERRAIN_NONE && uleft == null) l.add(new UnitAction(UnitAction.TYPE_PRODUCE,UnitAction.DIRECTION_LEFT,ut));
             }
         }
         

--- a/src/rts/units/Unit.java
+++ b/src/rts/units/Unit.java
@@ -337,34 +337,13 @@ public class Unit implements Serializable {
 
         PhysicalGameState pgs = s.getPhysicalGameState();
         Player p = pgs.getPlayer(player);
-
-        /*
-        Unit uup = pgs.getUnitAt(x,y-1);
-        Unit uright = pgs.getUnitAt(x+1,y);
-        Unit udown = pgs.getUnitAt(x,y+1);
-        Unit uleft = pgs.getUnitAt(x-1,y);
-        */
         
         // retrieves units around me
-        Unit uup = null, uright = null, udown = null, uleft = null;
-		for (Unit u : pgs.getUnits()) {
-			if (u.x == x) {
-				if (u.y == y - 1) {
-					uup = u;
-				} else if (u.y == y + 1) {
-					udown = u;
-				}
-			} else {
-				if (u.y == y) {
-					if (u.x == x - 1) {
-						uleft = u;
-					} else if (u.x == x + 1) {
-						uright = u;
-					}
-				}
-			}
-		}
-        
+        final Unit uup = pgs.getUnitAt(x,y-1);
+        final Unit uright = pgs.getUnitAt(x+1,y);
+        final Unit udown = pgs.getUnitAt(x,y+1);
+        final Unit uleft = pgs.getUnitAt(x-1,y);
+
 		// if this unit can attack, adds an attack action for each unit around it
         if (type.canAttack) {
             if (type.attackRange==1) {

--- a/src/rts/units/Unit.java
+++ b/src/rts/units/Unit.java
@@ -352,9 +352,9 @@ public class Unit implements Serializable {
                 if (y<pgs.getHeight()-1 && udown!=null && udown.player!=player && udown.player>=0) l.add(new UnitAction(UnitAction.TYPE_ATTACK_LOCATION,udown.x,udown.y));
                 if (x>0 && uleft!=null && uleft.player!=player && uleft.player>=0) l.add(new UnitAction(UnitAction.TYPE_ATTACK_LOCATION,uleft.x,uleft.y));                
             } else {
-                int sqrange = type.attackRange*type.attackRange;
-                // xxx(okachaaiev): this should be replaced as well
-                for(Unit u:pgs.getUnits()) {
+                final int sqrange = type.attackRange*type.attackRange;
+                // units outside the square won't make it into the circle
+                for(Unit u: pgs.getUnitsAround(x, y, type.attackRange)) {
                     if (u.player<0 || u.player==player) continue;
                     int sq_dx = (u.x - x)*(u.x - x);
                     int sq_dy = (u.y - y)*(u.y - y);

--- a/src/tests/JNIGridnetClient.java
+++ b/src/tests/JNIGridnetClient.java
@@ -166,9 +166,8 @@ public class JNIGridnetClient {
                 }
             }
         }
-        for (int i = 0; i < pgs.getUnits().size(); i++) {
-            Unit u = pgs.getUnits().get(i);
-            UnitActionAssignment uaa = gs.getUnitActions().get(u);
+        for (Unit u: pgs.getUnits()) {
+            final UnitActionAssignment uaa = gs.getActionAssignment(u);
             if (u.getPlayer() == player && uaa == null) {
                 masks[u.getY()][u.getX()][0] = 1;
                 UnitAction.getValidActionArray(u, gs, utt, masks[u.getY()][u.getX()], maxAttackRadius, 1);

--- a/src/tests/JNIGridnetClientSelfPlay.java
+++ b/src/tests/JNIGridnetClientSelfPlay.java
@@ -165,9 +165,8 @@ public class JNIGridnetClientSelfPlay {
                 }
             }
         }
-        for (int i = 0; i < pgs.getUnits().size(); i++) {
-            Unit u = pgs.getUnits().get(i);
-            UnitActionAssignment uaa = gs.getUnitActions().get(u);
+        for (Unit u: pgs.getUnits()) {
+            final UnitActionAssignment uaa = gs.getActionAssignment(u);
             if (u.getPlayer() == player && uaa == null) {
                 masks[player][u.getY()][u.getX()][0] = 1;
                 UnitAction.getValidActionArray(u, gs, utt, masks[player][u.getY()][u.getX()], maxAttackRadius, 1);

--- a/src/tests/JNIGridnetSharedMemClient.java
+++ b/src/tests/JNIGridnetSharedMemClient.java
@@ -160,9 +160,8 @@ public class JNIGridnetSharedMemClient {
     public void getMasks(int player) throws Exception {
         actionMaskBuffer.resetSegment(new int[]{clientOffset});
 
-        for (int i = 0; i < pgs.getUnits().size(); i++) {
-            Unit u = pgs.getUnits().get(i);
-            UnitActionAssignment uaa = gs.getUnitActions().get(u);
+        for (Unit u: pgs.getUnits()) {
+            final UnitActionAssignment uaa = gs.getActionAssignment(u);
             if (u.getPlayer() == player && uaa == null) {
                 final int[] idxOffset = new int[]{clientOffset, u.getY(), u.getX()};
                 UnitAction.getValidActionBuffer(u, gs, utt, actionMaskBuffer, maxAttackRadius, idxOffset);

--- a/src/tests/JNIGridnetSharedMemClientSelfPlay.java
+++ b/src/tests/JNIGridnetSharedMemClientSelfPlay.java
@@ -155,9 +155,8 @@ public class JNIGridnetSharedMemClientSelfPlay {
     public void getMasks(int player) throws Exception {
         actionMaskBuffer.resetSegment(new int[]{clientOffset+player});
 
-        for (int i = 0; i < pgs.getUnits().size(); i++) {
-            Unit u = pgs.getUnits().get(i);
-            UnitActionAssignment uaa = gs.getUnitActions().get(u);
+        for (Unit u: pgs.getUnits()) {
+            final UnitActionAssignment uaa = gs.getActionAssignment(u);
             if (u.getPlayer() == player && uaa == null) {
                 final int[] idxOffset = new int[]{clientOffset+player, u.getY(), u.getX()};
                 UnitAction.getValidActionBuffer(u, gs, utt, actionMaskBuffer, maxAttackRadius, idxOffset);


### PR DESCRIPTION
The issue is briefly described [here](https://github.com/kachayev/microrts/issues/1). There are a few places in the code where the system scans units quadratically by performing nested `getUnitAt` calls. E.g. when finding units around a given unit. To eliminate large number of linear scans over the list of units I added a cache from unit position into unit index that is computed once after each game cycle.

During the game cycle previous method is used (because unit position might be change leading to cache being stale). This could be  improved as well but would require much deeper changes into the game itself.