### PR TITLE
Improved runtime complexity of game state integrityCheck calls

### DIFF
--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -685,14 +685,14 @@ public class GameState {
      * @return
      */
     public boolean integrityCheck() {
-        List<Unit> alreadyUsed = new LinkedList<Unit>();
-        for(UnitActionAssignment uaa:unitActions.values()) {
-            Unit u = uaa.unit;
+        final Set<Unit> alreadyUsed = new HashSet<Unit>(pgs.getUnits().size());
+        for(UnitActionAssignment uaa: unitActions.values()) {
+            final Unit u = uaa.unit;
             int idx = pgs.getUnits().indexOf(u);
             if (idx==-1) {
                 System.err.println("integrityCheck: unit does not exist!");
                 return false;
-            }            
+            }
             if (alreadyUsed.contains(u)) {
                 System.err.println("integrityCheck: two actions to the same unit!");
                 return false;

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -685,11 +685,15 @@ public class GameState {
      * @return
      */
     public boolean integrityCheck() {
-        final Set<Unit> alreadyUsed = new HashSet<Unit>(pgs.getUnits().size());
+        final int numUnits = pgs.getUnits().size();
+        final Set<Unit> allUnits = new HashSet<Unit>(numUnits);
+        final Set<Unit> alreadyUsed = new HashSet<Unit>(numUnits);
+        for(Unit u: pgs.getUnits()) {
+            allUnits.add(u);
+        }
         for(UnitActionAssignment uaa: unitActions.values()) {
             final Unit u = uaa.unit;
-            int idx = pgs.getUnits().indexOf(u);
-            if (idx==-1) {
+            if (!allUnits.contains(u)) {
                 System.err.println("integrityCheck: unit does not exist!");
                 return false;
             }


### PR DESCRIPTION
The problem is described [here](https://github.com/kachayev/microrts/issues/3). 

Existing implementation of `integrityCheck` does 
* linear scan over units for each action issued (`indexOf`)
* another linear scan over all previously seen units (`contains`)

Yielding quadratic with respect to number of units on the board performance.

The solution is to replace linked lists with hash sets (for both operations). Both `HashSet` pre-allocates enough capacity for all units to avoid reallocation penalty. Equality check is executed for both linked list and hash sets, performance hit for computing hash is negligible (and constant). 

Opening this as a draft, while tests are running.